### PR TITLE
Corrections to references of route/service for parksmap and mlbparks

### DIFF
--- a/databases.adoc
+++ b/databases.adoc
@@ -283,14 +283,14 @@ arbitrary key=value pair. It could be anything.
 * `openshift=awesome`
 
 In the case of the parks map, the application is actually querying the OpenShift
-API and asking about the *Routes* in the project. If any of them have a
+API and asking about the *Routes* and *Services* in the project. If any of them have a
 *Label* that is `type=parksmap-backend`, the application knows to interrogate
-that service's endpoints to look for map data.
+the endpoints to look for map data.
 {% if PARKSMAP_PY %}
-You can see the code that does this link:https://github.com/openshift-roadshow/parksmap-web-py/blob/1.0.0/app.py#L85[here].
+You can see the code that does this link:https://github.com/openshift-roadshow/parksmap-web-py/blob/1.0.0/app.py#L97[here].
 {% else %}
 You can see the code that does this
-link:https://github.com/openshift-roadshow/parksmap-web/blob/{{PARKSMAP_VERSION}}/src/main/java/com/openshift/evg/roadshow/rest/ServiceWatcher.java#L20[here].
+link:https://github.com/openshift-roadshow/parksmap-web/blob/{{PARKSMAP_VERSION}}/src/main/java/com/openshift/evg/roadshow/rest/RouteWatcher.java#L20[here].
 {% endif %}
 
 

--- a/templates.adoc
+++ b/templates.adoc
@@ -228,7 +228,7 @@ OpenShift will now:
 ** Using auto-generated user, password, and database name
 * Configure environment variables for the app to connect to the DB
 * Create the correct services
-* Label the app route with `type=parksmap-backend`
+* Label the app service with `type=parksmap-backend`
 
 All with one command!
 


### PR DESCRIPTION
[parksmap-web:1.2.0](https://github.com/openshift-roadshow/parksmap-web/tree/1.2.0/src/main/java/com/openshift/evg/roadshow/rest) checks Route and Service.  Modified text to reflect accordingly.  Changed the source code references to the route's since that's the what the lab is changing.

[mlbparks application-template](https://raw.githubusercontent.com/openshift-roadshow/mlbparks/1.0.0/ose3/application-template-eap.json) only adds the label `type=parksmap-backend` to the service.