### PR TITLE
Don't show image trigger on dc/nationalparks

### DIFF
--- a/codechanges.adoc
+++ b/codechanges.adoc
@@ -221,7 +221,11 @@ NAME                 REVISION   DESIRED   CURRENT   TRIGGERED BY
 jenkins              1          1         1         config,image(jenkins:latest)
 mongodb              1          1         1         config,image(mongodb:3.2)
 mongodb-live         1          1         1         config,image(mongodb:3.2)
+{% if modules.pipelines %}
 nationalparks        9          1         1         config
+{% else %}
+nationalparks        9          1         1         config,image(nationalparks:latest)
+{% endif %}
 nationalparks-live   4          1         1         config,image(nationalparks:live)
 parksmap             2          1         1         config,image(parksmap:{{PARKSMAP_VERSION}})
 ----

--- a/codechanges.adoc
+++ b/codechanges.adoc
@@ -221,7 +221,7 @@ NAME                 REVISION   DESIRED   CURRENT   TRIGGERED BY
 jenkins              1          1         1         config,image(jenkins:latest)
 mongodb              1          1         1         config,image(mongodb:3.2)
 mongodb-live         1          1         1         config,image(mongodb:3.2)
-nationalparks        9          1         1         config,image(nationalparks:latest)
+nationalparks        9          1         1         config
 nationalparks-live   4          1         1         config,image(nationalparks:live)
 parksmap             2          1         1         config,image(parksmap:{{PARKSMAP_VERSION}})
 ----


### PR DESCRIPTION
When following the workshop the trigger was removed before creating
the `nationalparks-pipeline`. Therefore it shouldn't' show up, when
listing the deploymentconfig.

See https://github.com/osevg/workshopper-content/blame/master/pipelines.adoc#L297