### PR TITLE
typo - add $ prefix to oc label command

### DIFF
--- a/databases-py.adoc
+++ b/databases-py.adoc
@@ -312,7 +312,13 @@ You see that it only has one label: `app=nationalparks`. Now, use `oc label`:
 
 [source]
 ----
-oc label route nationalparks type=parksmap-backend
+$ oc label route nationalparks type=parksmap-backend
+----
+
+You will see something like:
+
+[source]
+----
 route "nationalparks" labeled
 ----
 


### PR DESCRIPTION
and split output so it's obviously not part of the command