### PR TITLE
Variablize storage type and consolidate SUFFIX into USER_SUFFIX

### DIFF
--- a/_modules.yml
+++ b/_modules.yml
@@ -108,6 +108,9 @@ config:
     - name: OPENSHIFT_VERSION      
       desc: OpenShift version used in the workshop
       value: "3.5"
+    - name: STORAGE_TYPE
+      desc: Should they be using ephemeral or persistant storage?
+      value: ephemeral
 
 modules:
   environment:

--- a/_modules.yml
+++ b/_modules.yml
@@ -60,9 +60,6 @@ config:
     - name: EXPLORE_PROJECT_NAME
       desc: Project the user is supposed to work with
       value: project
-    - name: SUFFIX
-      desc: Username suffix
-      value: XY
     - name: PARKSMAP_IMAGENAME
       desc: Docker image name for the parksmap application
       value: <image name>

--- a/databases-py.adoc
+++ b/databases-py.adoc
@@ -44,10 +44,10 @@ persistent storage!). The image will ensure that:
 - The user can access the specified database with the specified password
 
 In the web console in your `{{EXPLORE_PROJECT_NAME}}{{USER_SUFFIX}}` project, again click the *"Add to
-Project"* button, and then find the `mongodb-ephemeral` template, and click it.
+Project"* button, and then find the `mongodb-{{STORAGE_TYPE}}` template, and click it.
 You will notice that there are several MongoDB templates available, some of
 which come with application servers pre-configured. We just need a database,
-though, so `mongodb-ephemeral` is what you should choose.
+though, so `mongodb-{{STORAGE_TYPE}}` is what you should choose.
 
 image::ocp-mongodb-template.png[MongoDB]
 

--- a/databases.adoc
+++ b/databases.adoc
@@ -57,9 +57,9 @@ again click the *"Add to Project"* button. Click the *Data Stores* category.
 image::mongodb-datastores.png[Data Stores]
 
 Type `mongodb` in the search box, and then scroll down to find the *MongoDB
-(Ephemeral)* template, and click it.  You will notice that there are several
+({{STORAGE_TYPE}})* template, and click it.  You will notice that there are several
 MongoDB templates available, some of which come with application servers
-pre-configured.  We just need a database, though, so the ephemeral Mongo
+pre-configured.  We just need a database, though, so the {{STORAGE_TYPE}} Mongo
 template is what you should choose.
 
 image::ocp-mongodb-template.png[MongoDB]

--- a/permissions.adoc
+++ b/permissions.adoc
@@ -62,7 +62,7 @@ access to your `explore` project using the following command:
 
 [source,role=copypaste]
 ----
-$ oc policy add-role-to-user view user{{SUFFIX}}
+$ oc policy add-role-to-user view user{{USER_SUFFIX}}
 ----
 
 Have them go to the project view by clicking the *Projects* button and verify

--- a/pipelines.adoc
+++ b/pipelines.adoc
@@ -54,9 +54,9 @@ Integration & Deployment*:
 
 image::pipeline-technologies.png[CI/CD Technologies]
 
-Find the `jenkins-ephemeral` template, and click on it:
+Find the `jenkins-{{STORAGE_TYPE}}` template, and click on it:
 
-image::pipeline-jenkins-catalog.png[Jenkins Ephemeral]
+image::pipeline-jenkins-catalog.png[Jenkins {{STORAGE_TYPE}}]
 
 You can customize the Jenkins properties such as service name, admin password, memory
 allocation, etc through the parameters in the web console. We can leave all of
@@ -116,7 +116,7 @@ changes in the *Dev* deployment without interfering with the live application.
 #### Live MongoDB
 First you need to create a new MongoDB deployment for the *Live* environment. In the
 web console in your `{{EXPLORE_PROJECT_NAME}}{{USER_SUFFIX}}` project,  click the *Add to
-Project* button, and then find the `mongodb-ephemeral` template, and click it.
+Project* button, and then find the `mongodb-{{STORAGE_TYPE}}` template, and click it.
 Use the following values in their respective fields:
 
 * Database Service Name : `mongodb-live`


### PR DESCRIPTION
SUFFIX was used in one place as a reference back to the USER_SUFFIX, but had to be defined separately. Doesn't really make sense, imo.

Internally we wanted to be able to show people how to use the persistent storage a bit, and it takes up less disk on the worker nodes, so we wanted to be able to set that in the roadshow.  So we added that as a variable, defaulting to ephemeral.