### PR TITLE
fixing workshop_type for node.js

### DIFF
--- a/apb/roles/provision-java-starter-guides/tasks/install-gogs.yml
+++ b/apb/roles/provision-java-starter-guides/tasks/install-gogs.yml
@@ -33,7 +33,7 @@
   command: git clone https://github.com/openshift-roadshow/{{ reponame }}-js.git {{ reponame }}
   args:
     chdir: "{{ tmp_dir.path }}"
-  when: workshop_type == "nodejs"
+  when: workshop_type == "node.js"
 - name: "Create local repository to push to git (PHP version)"
   command: git clone https://github.com/openshift-roadshow/{{ reponame }}-php.git {{ reponame }}
   args:


### PR DESCRIPTION
workshop_type needs to be "node.js" rather than "nodejs" to fix a provisioning error