### PR TITLE
make the etherpad content templated

### DIFF
--- a/apb/roles/provision-java-starter-guides/files/etherpad.txt
+++ b/apb/roles/provision-java-starter-guides/files/etherpad.txt
@@ -1,3 +1,0 @@
-Welcome to the \"Getting started for Developers\" on OpenShift Workshop.
-
-Assign yourself a user:

--- a/apb/roles/provision-java-starter-guides/tasks/install-etherpad.yml
+++ b/apb/roles/provision-java-starter-guides/tasks/install-etherpad.yml
@@ -2,16 +2,10 @@
 #####
 # Etherpad
 #####
-- name: "Copy etherpad base text file"
-  copy:
-    src: etherpad.txt
+- name: "Create etherpad base text file from template"
+  template:
+    src: etherpad.txt.j2
     dest: "{{ tmp_dir.path }}/etherpad.txt"
-
-- name: Add {{ user_count }} to etherpad.txt file
-  lineinfile:
-    path: "{{ tmp_dir.path }}/etherpad.txt"
-    line: "{{ item }}"
-  with_sequence: start=1 end={{ user_count }} format="{{ user_format }}="
 
 - set_fact:
     etherpad_text: "{{ lookup('file', '{{ tmp_dir.path }}/etherpad.txt') | replace('\n', '\\n')}}"

--- a/apb/roles/provision-java-starter-guides/templates/etherpad.txt.j2
+++ b/apb/roles/provision-java-starter-guides/templates/etherpad.txt.j2
@@ -1,0 +1,20 @@
+Welcome to the \"Getting started for Developers\" on OpenShift Workshop.
+
+If this is your first time using an Etherpad, it allows EVERYONE to edit
+documents collaboratively in real-time, much like a live multi-player editor
+that runs in your browser. To-do lists, notes, questions, follow ups; we can
+all work on the same document at the same time.
+
+To start using this collaboration tool, we are going to identify some logistics.
+
+Find an open user login and assign yourself one, remember it, you'll use this
+to login:
+
+{% for user_num in range(1, user_count|int + 1) %}
+user{{ user_num }}=
+{% endfor %}
+
+Parking Lot
+-----------
+If there is anything we don\'t have time to cover, record it here.
+


### PR DESCRIPTION
Add a nicer snippet and generate the user numbers correctly.

I mostly want an easier way to make adjustments for other workshops...

I ran a few tests, but did not provision with it.  

[etherpad-user_count_7.txt](https://github.com/openshift-labs/starter-guides/files/2854060/etherpad-user_count_7.txt)
[etherpad-user_count_13.txt](https://github.com/openshift-labs/starter-guides/files/2854063/etherpad-user_count_13.txt)
[etherpad-user_count_103.txt](https://github.com/openshift-labs/starter-guides/files/2854064/etherpad-user_count_103.txt)
