### PR TITLE
Use latest terminal spawner gear in APB provision

### DIFF
--- a/apb/roles/provision-java-starter-guides/tasks/install-terminals.yml
+++ b/apb/roles/provision-java-starter-guides/tasks/install-terminals.yml
@@ -1,26 +1,27 @@
 ---
 #####
-# Terminals: 
+# Terminals:
 # https://raw.githubusercontent.com/openshift-evangelists/training-openshift-auth/master/examples/terminal-base.json
 #####
 - name: "Process terminals template"
   template:
-    src: terminals.yml
-    dest: "{{ tmp_dir.path }}/terminals.yml"
+    src: hosted-workshop-production.json
+    dest: "{{ tmp_dir.path }}/hosted-workshop-production.json"
 
 - name: Add terminals template to {{ namespace }}
-  command: "oc apply -f {{ tmp_dir.path }}/terminals.yml -n {{ namespace }}"
+  command: "oc apply -f {{ tmp_dir.path }}/hosted-workshop-production.json -n {{ namespace }}"
 
 - name: Create terminals resources
   shell: >
         oc new-app terminal-base-openshift-auth
         -p ADMIN_USERS={{ openshift_user }}
+        -p APPLICATION_NAME=terminal
         -n {{ namespace }}
-        --dry-run -o yaml > terminals.yml
+        --dry-run -o json > hosted-workshop-production.json
   args:
     chdir: "{{ tmp_dir.path }}"
 
 - name: Apply terminals objects
-  command: "oc apply -f terminals.yml -n {{ namespace }}"
+  command: "oc apply -f hosted-workshop-production.json -n {{ namespace }}"
   args:
     chdir: "{{ tmp_dir.path }}"

--- a/apb/roles/provision-java-starter-guides/templates/hosted-workshop-production.json
+++ b/apb/roles/provision-java-starter-guides/templates/hosted-workshop-production.json
@@ -1,0 +1,370 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "hosted-workshop-production",
+        "annotations": {
+            "openshift.io/display-name": "Hosted Workshop (Production)"
+        }
+    },
+    "parameters": [
+        {
+            "name": "APPLICATION_NAME",
+            "value": "workshop",
+            "required": true
+        },
+        {
+            "name": "WORKSHOP_MEMORY",
+            "value": "512Mi"
+        },
+        {
+            "name": "CONSOLE_MEMORY",
+            "value": "128Mi"
+        },
+        {
+            "name": "VOLUME_SIZE",
+            "value": ""
+        },
+        {
+            "name": "ADMIN_USERS",
+            "value": ""
+        },
+        {
+            "name": "USER_LOGINS",
+            "value": ""
+        },
+        {
+            "name": "IDLE_TIMEOUT",
+            "value": "7200"
+        },
+        {
+            "name": "TERMINAL_IMAGE",
+            "value": "",
+            "required": false
+        },
+        {
+            "name": "JUPYTERHUB_IMAGE",
+            "value": "quay.io/openshiftlabs/workshop-jupyterhub:2.8.3",
+            "required": true
+        },
+        {
+            "name": "OC_VERSION",
+            "value": ""
+        },
+        {
+            "name": "ODO_VERSION",
+            "value": ""
+        },
+        {
+            "name": "KUBECTL_VERSION",
+            "value": ""
+        },
+        {
+            "name": "JUPYTERHUB_CONFIG",
+            "value": "",
+            "required": false
+        }
+    ],
+    "objects": [
+        {
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-hub",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "serviceaccounts.openshift.io/oauth-redirectreference.first": "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"${APPLICATION_NAME}\"}}",
+                    "serviceaccounts.openshift.io/oauth-redirecturi.first": "hub/oauth_callback",
+                    "serviceaccounts.openshift.io/oauth-want-challenges": "false"
+                }
+            }
+        },
+        {
+            "kind": "RoleBinding",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-edit",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "subjects": [
+                {
+                    "kind": "ServiceAccount",
+                    "name": "${APPLICATION_NAME}-hub"
+                }
+            ],
+            "roleRef": {
+                "name": "edit"
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-hub",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "${JUPYTERHUB_IMAGE}"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ConfigMap",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-cfg",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "data": {
+                "jupyterhub_config.py": "${JUPYTERHUB_CONFIG}",
+                "user_logins.csv": "${USER_LOGINS}"
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "spawner"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "${APPLICATION_NAME}-hub:latest"
+                            }
+                        }
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "app": "${APPLICATION_NAME}",
+                    "deploymentconfig": "${APPLICATION_NAME}"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app": "${APPLICATION_NAME}",
+                            "deploymentconfig": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "serviceAccountName": "${APPLICATION_NAME}-hub",
+                        "containers": [
+                            {
+                                "name": "spawner",
+                                "image": "${APPLICATION_NAME}-hub:latest",
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "CONFIGURATION_TYPE",
+                                        "value": "hosted-workshop"
+                                    },
+                                    {
+                                        "name": "APPLICATION_NAME",
+                                        "value": "${APPLICATION_NAME}"
+                                    },
+                                    {
+                                        "name": "TERMINAL_IMAGE",
+                                        "value": "${TERMINAL_IMAGE}"
+                                    },
+                                    {
+                                        "name": "WORKSHOP_MEMORY",
+                                        "value": "${WORKSHOP_MEMORY}"
+                                    },
+                                    {
+                                        "name": "CONSOLE_MEMORY",
+                                        "value": "${CONSOLE_MEMORY}"
+                                    },
+                                    {
+                                        "name": "VOLUME_SIZE",
+                                        "value": "${VOLUME_SIZE}"
+                                    },
+                                    {
+                                        "name": "ADMIN_USERS",
+                                        "value": "${ADMIN_USERS}"
+                                    },
+                                    {
+                                        "name": "IDLE_TIMEOUT",
+                                        "value": "${IDLE_TIMEOUT}"
+                                    },
+                                    {
+                                        "name": "OC_VERSION",
+                                        "value": "${OC_VERSION}"
+                                    },
+                                    {
+                                        "name": "ODO_VERSION",
+                                        "value": "${ODO_VERSION}"
+                                    },
+                                    {
+                                        "name": "KUBECTL_VERSION",
+                                        "value": "${KUBECTL_VERSION}"
+                                    }
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/opt/app-root/data",
+                                        "name": "data"
+                                    },
+                                    {
+                                        "name": "config",
+                                        "mountPath": "/opt/app-root/configs"
+                                    }
+                                ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "data",
+                                "persistentVolumeClaim": {
+                                    "claimName": "${APPLICATION_NAME}-hub-data"
+                                }
+                            },
+                            {
+                                "name": "config",
+                                "configMap": {
+                                    "name": "${APPLICATION_NAME}-cfg",
+                                    "defaultMode": 420
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-hub-data",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteOnce"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "1Gi"
+                    }
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "8080-tcp",
+                        "protocol": "TCP",
+                        "port": 8080,
+                        "targetPort": 8080
+                    },
+                    {
+                        "name": "8081-tcp",
+                        "protocol": "TCP",
+                        "port": 8081,
+                        "targetPort": 8081
+                    }
+                ],
+                "selector": {
+                    "app": "${APPLICATION_NAME}",
+                    "deploymentconfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "host": "",
+                "to": {
+                    "kind": "Service",
+                    "name": "${APPLICATION_NAME}",
+                    "weight": 100
+                },
+                "port": {
+                    "targetPort": "8080-tcp"
+                },
+                "tls": {
+                    "termination": "edge",
+                    "insecureEdgeTerminationPolicy": "Redirect"
+                }
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-app",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "lookupPolicy": {
+                    "local": true
+                },
+                "tags": [
+                    {
+                        "name": "latest",
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "quay.io/openshiftlabs/workshop-terminal:2.2.0"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add `provision-java/templates/hosted-workshop-production.json` file 
copied from 
https://github.com/openshift-labs/workshop-jupyterhub/blob/2.8.3/templates/hosted-workshop-production.json

Replace references in `tasks/install-terminals.yml` to terminals.yml 
with refs to new file.

Cf. https://trello.com/c/4N0ARkp7