### PR TITLE
hosted-workshop-prod: Update to v2.11.1

### DIFF
--- a/apb/roles/provision-java-starter-guides/templates/hosted-workshop-production.json
+++ b/apb/roles/provision-java-starter-guides/templates/hosted-workshop-production.json
@@ -44,7 +44,7 @@
         },
         {
             "name": "JUPYTERHUB_IMAGE",
-            "value": "quay.io/openshiftlabs/workshop-jupyterhub:2.10.2",
+            "value": "quay.io/openshiftlabs/workshop-jupyterhub:2.11.1",
             "required": true
         },
         {


### PR DESCRIPTION
Copy the latest version of file `hosted-workshop-production.json` from 
https://github.com/openshift-labs/workshop-jupyterhub/blob/2.11.1/templates/hosted-workshop-production.json