### PR TITLE
hosted-workshop-prod: Update to v3.0.5

### DIFF
--- a/apb/roles/provision-java-starter-guides/templates/etherpad.txt.j2
+++ b/apb/roles/provision-java-starter-guides/templates/etherpad.txt.j2
@@ -7,7 +7,7 @@ all work on the same document at the same time.
 
 To start using this collaboration tool, we are going to identify some logistics.
 
-Find an open user login and assign yourself one, remember it, you'll use this
+Find an open user login and assign yourself one. Remember it, you will use it
 to login:
 
 {% for user_num in range(1, user_count|int + 1) %}
@@ -16,5 +16,4 @@ user{{ user_num }}=
 
 Parking Lot
 -----------
-If there is anything we don\'t have time to cover, record it here.
-
+If there is anything we do not have time to cover, record it here.

--- a/apb/roles/provision-java-starter-guides/templates/hosted-workshop-production.json
+++ b/apb/roles/provision-java-starter-guides/templates/hosted-workshop-production.json
@@ -43,9 +43,17 @@
             "required": false
         },
         {
-            "name": "JUPYTERHUB_IMAGE",
-            "value": "quay.io/openshiftlabs/workshop-jupyterhub:2.11.1",
+            "name": "SPAWNER_IMAGE",
+            "value": "quay.io/openshiftlabs/workshop-spawner:3.0.5",
             "required": true
+        },
+        {
+            "name": "TERMINAL_ENVVARS",
+            "value": ""
+        },
+        {
+            "name": "WORKSHOP_ENVVARS",
+            "value": ""
         },
         {
             "name": "OC_VERSION",
@@ -124,7 +132,7 @@
                         "name": "latest",
                         "from": {
                             "kind": "DockerImage",
-                            "name": "${JUPYTERHUB_IMAGE}"
+                            "name": "${SPAWNER_IMAGE}"
                         }
                     }
                 ]
@@ -142,6 +150,20 @@
             "data": {
                 "jupyterhub_config.py": "${JUPYTERHUB_CONFIG}",
                 "user_logins.csv": "${USER_LOGINS}"
+            }
+        },
+        {
+            "kind": "ConfigMap",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}-env",
+                "labels": {
+                    "app": "${APPLICATION_NAME}"
+                }
+            },
+            "data": {
+                "terminal.sh": "${TERMINAL_ENVVARS}",
+                "workshop.sh": "${WORKSHOP_ENVVARS}"
             }
         },
         {
@@ -372,7 +394,7 @@
                         "name": "latest",
                         "from": {
                             "kind": "DockerImage",
-                            "name": "quay.io/openshiftlabs/workshop-terminal:2.2.0"
+                            "name": "quay.io/openshiftlabs/workshop-terminal:2.6.1"
                         }
                     }
                 ]


### PR DESCRIPTION
Copy the latest release of hosted-workshop-production.json from
https://github.com/openshift-labs/workshop-spawner/blob/3.0.5/templates/hosted-workshop-production.json