### PR TITLE
deprovision/tasks/main: Deprovision terminal

### DIFF
--- a/apb/roles/deprovision-java-starter-guides/tasks/main.yml
+++ b/apb/roles/deprovision-java-starter-guides/tasks/main.yml
@@ -13,8 +13,10 @@
     - etherpad
     - gogs
     - nexus
-    - starter-guides
     - ocp-ops-view
+    - ocp-ops-view-redis
+    - starter-guides
+    - terminal
 
 # Remove users projects
 - name: Delete user projects


### PR DESCRIPTION
Add terminal app labels to the oc delete list built in
deprovision/tasks/main.
Add ocp-ops-view-redis app label to list, to catch the service with that
label only.