### PR TITLE
locked DOCS_URL to 3.11

### DIFF
--- a/_modules.yml
+++ b/_modules.yml
@@ -26,7 +26,7 @@ config:
     # 
     - name: DOCS_URL
       desc: URL prefix to access docs (docs.openshift.org/latest) without the protocol prefix. (https:// will be used.)
-      value: docs.openshift.com/container-platform/latest
+      value: docs.openshift.com/container-platform/3.11
     ##
     # Module environment
     # 


### PR DESCRIPTION
Docs should point to 3.11 in this branch, as latest is now 4.x