### PR TITLE
fix git repo url

### DIFF
--- a/workshop/content/nationalparks-python.adoc
+++ b/workshop/content/nationalparks-python.adoc
@@ -95,7 +95,7 @@ Enter the following for Git Repo URL:
 
 [source,role=copypaste]
 ----
-http://gogs-{{INFRA_PROJECT}}.{{cluster_subdomain}}/{{username}}/nationalparks.git
+http://gogs-{{INFRA_PROJECT}}.{{cluster_subdomain}}/{{username}}/nationalparks-py.git
 ----
 
 Select Python as your Builder Image.


### PR DESCRIPTION
copy/paste url pointed to the java app, not the python app

Additionally, the referenced image workshop/content/images/nationalparks-import-from-git-url-builder.png illustrates the Java builder image rather than the python builder image. It would ideally be the latter.