### PR TITLE
fix gogs repo url

### DIFF
--- a/workshop/content/nationalparks-python-codechanges-gogs.adoc
+++ b/workshop/content/nationalparks-python-codechanges-gogs.adoc
@@ -17,7 +17,7 @@ image::images/nationalparks-pipeline-codechanges-webhook-config.png[Webhook]
 Click *Copy URL with Secret*. Once you have the URL copied to your clipboard, navigate to the code repository
 that you have on Gogs:
 
-link:http://gogs-{{INFRA_PROJECT}}.{{cluster_subdomain}}/{{username}}/nationalparks[Gogs Repository]
+link:http://gogs-{{INFRA_PROJECT}}.{{cluster_subdomain}}/{{username}}/nationalparks-py[Gogs Repository]
 
 Your Gogs credentials are:
 


### PR DESCRIPTION
Gogs link went to java repo while the document content is for the python repo