### PR TITLE
Update parksmap-docker.adoc

### DIFF
--- a/workshop/content/parksmap-docker.adoc
+++ b/workshop/content/parksmap-docker.adoc
@@ -21,8 +21,7 @@ In the *Image Name* field, copy/paste the following into the box:
 quay.io/openshiftroadshow/{{PARKSMAP_IMAGENAME}}:{{PARKSMAP_VERSION}}
 ----
 
-Either press *enter* or click on the magnifying glass. OpenShift will then go
-out to the container registry specified and interrogate the image.
+OpenShift will then go out to the container registry specified and interrogate the image.
 
 Your screen will end up looking something like this:
 


### PR DESCRIPTION
Fixed docs bug.   In OCP 4 there is no magnifying glass and pressing 'Enter' will end up triggering the 'Create' action prematurely.