### PR TITLE
Fix incorrect line number in documentation

### DIFF
--- a/workshop/content/nationalparks-javascript-codechanges-gogs.adoc
+++ b/workshop/content/nationalparks-javascript-codechanges-gogs.adoc
@@ -69,7 +69,7 @@ hand corner as shown here:
 
 image::images/nationalparks-codechanges-gogs-javascript-change-code.png[Webhook]
 
-Change line number 17:
+Change line number 18:
 
 [source,javascript]
 ----


### PR DESCRIPTION
This is a very small fix but the line number in the documentation was wrongly saying "17" instead of "18".

This very small fix just ensures that people attempting this task change the correct line.
