### PR TITLE
Clarify wording to switch back to Topology page.

### DIFF
--- a/workshop/content/parksmap-container-image.adoc
+++ b/workshop/content/parksmap-container-image.adoc
@@ -206,7 +206,7 @@ node does not already have it cached locally. You can check on the status of the
 image download and deployment in the *Pod* details page, or from the command
 line with the `oc get pods` command that you used before.
 
-The default view in the *Developer* console is *Graph View*. You can switch between *Graph* and *List* views by using the toggle in the top right of the console.
+Back on the The *Topology* page, the default view in the *Developer* console is *Graph View*. You can switch between *Graph* and *List* views by using the toggle in the top right of the console.
 
 image::images/nationalparks-listview.png[List View Toggle]
 


### PR DESCRIPTION
It isn't made obvious that the user needs to return to the topology page to find the "3 dots" button that's pictured to switch between graph and list view.